### PR TITLE
Tackle Packet Timing in steps

### DIFF
--- a/apps/dexdrip/dexdrip.c
+++ b/apps/dexdrip/dexdrip.c
@@ -222,8 +222,8 @@ void goToSleep (uint16 seconds) {
         IEN0 |= 0x20; // Enable global ST interrupt [IEN0.STIE]
         WORIRQ |= 0x10; // enable sleep timer interrupt [EVENT0_MASK]
 
-        SLEEP |= 0x02;                  // SLEEP.MODE = PM2
-        /*SLEEP |= 0x01;                  // SLEEP.MODE = PM2*/
+        /*SLEEP |= 0x02;                  // SLEEP.MODE = PM2*/
+        SLEEP |= 0x01;                  // SLEEP.MODE = PM2
 
         if(do_close_usb)
         {
@@ -329,7 +329,7 @@ uint8 WaitForPacket(uint16 milliseconds, Dexcom_packet* pkt, uint8 channel) {
 uint8 get_packet(Dexcom_packet* pPkt, uint32 XDATA channel_wait) {
     uint8 nChannel = 0;
     uint8 XDATA fixed_channel = 0;
-    uint32 delay = channel_wait + 50;
+    uint32 delay = channel_wait + 500;
 
     for(nChannel = start_channel; nChannel < NUM_CHANNELS; nChannel++) {
         if (fixed_channel == 1) {
@@ -339,6 +339,8 @@ uint8 get_packet(Dexcom_packet* pPkt, uint32 XDATA channel_wait) {
         }
         switch(WaitForPacket(delay, pPkt, nChannel)) {
         case 1:
+            LED_RED(0);
+            LED_YELLOW(0);
             return 1;
         case 0:
             if (nChannel == 3) {
@@ -348,7 +350,7 @@ uint8 get_packet(Dexcom_packet* pPkt, uint32 XDATA channel_wait) {
             continue;
         }
         if (nChannel == 2) {
-            delay = wait_before_channel_switch - 50;
+            delay = wait_before_channel_switch - 500;
         } else {
             delay = wait_before_channel_switch;
         }
@@ -430,7 +432,7 @@ void timing_setup() {
         RFST = 4;
         delayMs(80);
         doServices();
-        goToSleep(100 + ((initial_wait / 1000) - 2));
+        goToSleep(100 + ((initial_wait / 1000) - 5));
         USBPOW = 1;
         USBCIE = 0b0111;
         radioMacInit();
@@ -452,7 +454,7 @@ void timing_setup() {
         RFST = 4;
         delayMs(80);
         doServices();
-        goToSleep(100 + ((initial_wait / 1000) - 2));
+        goToSleep(100 + ((initial_wait / 1000) - 5));
         USBPOW = 1;
         USBCIE = 0b0111;
         radioMacInit();
@@ -473,7 +475,7 @@ void timing_setup() {
         RFST = 4;
         delayMs(80);
         doServices();
-        goToSleep(100 + ((initial_wait / 1000) - 2));
+        goToSleep(100 + ((initial_wait / 1000) - 5));
         USBPOW = 1;
         USBCIE = 0b0111;
         radioMacInit();
@@ -528,15 +530,17 @@ void main() {
             continue;
 
         print_packet(&Pkt);
+        LED_YELLOW(1);
 
         if(getMs() > (60000 * 5)) {
             timing_setup();
         }
+        LED_YELLOW(0);
         LED_RED(0);
         RFST = 4;
         delayMs(80);
         doServices();
-        goToSleep(100 + ((initial_wait / 1000) - 2));
+        goToSleep(100 + ((initial_wait / 1000) - 5));
         USBPOW = 1;
         USBCIE = 0b0111;
         radioMacInit();

--- a/apps/dexdrip/dexdrip.c
+++ b/apps/dexdrip/dexdrip.c
@@ -411,8 +411,6 @@ void timing_setup() {
         LED_GREEN(0);
     //sleep default, then wait on channel 1
         while (initial_wait == 0 || initial_wait > five_minutes){
-            LED_GREEN(1);
-            while(!get_packet_fixed_channel(&Pkt, 0)) {}
             RFST = 4;
             delayMs(80);
             doServices();
@@ -423,10 +421,12 @@ void timing_setup() {
             MCSM1 = 0;
             radioMacStrobe();
 
-            timeInit();
             memset(&Pkt, 0, sizeof(Dexcom_packet));
             boardService();
 
+            timeInit();
+            LED_GREEN(1);
+            while(!get_packet_fixed_channel(&Pkt, 0)) {}
             print_packet(&Pkt);
             LED_GREEN(0);
             initial_wait = getMs();
@@ -453,17 +453,17 @@ void timing_setup() {
             boardService();
             timeInit();
             LED_GREEN(1);
-            while(!get_packet_fixed_channel(&Pkt, 1)) {}
-
+            while(!get_packet_fixed_channel(&Pkt, 3)) {}
             print_packet(&Pkt);
             LED_GREEN(0);
             first_wait_fourth_channel = getMs() + 100;
         }
 
     //Get back into timing for channel 1
-        rest(initial_wait - 1000);
+        rest(initial_wait - 10);
         memset(&Pkt, 0, sizeof(Dexcom_packet));
         boardService();
+        timeInit();
         LED_GREEN(1);
         while(!get_packet_fixed_channel(&Pkt, 0)) {}
         LED_GREEN(0);
@@ -499,11 +499,11 @@ void main() {
         timeInit();
         memset(&Pkt, 0, sizeof(Dexcom_packet));
         boardService();
+        LED_YELLOW(1);
         if(!get_packet(&Pkt, fixed_wait_adder))
             continue;
 
         print_packet(&Pkt);
-        LED_YELLOW(1);
 
         if(getMs() > five_minutes) {
             timing_setup();

--- a/apps/dexdrip/dexdrip.c
+++ b/apps/dexdrip/dexdrip.c
@@ -408,7 +408,7 @@ void timing_setup() {
         RFST = 4;
         delayMs(80);
         doServices();
-        goToSleep(220);
+        goToSleep(100);
         USBPOW = 1;
         USBCIE = 0b0111;
         radioMacInit();
@@ -430,7 +430,7 @@ void timing_setup() {
         RFST = 4;
         delayMs(80);
         doServices();
-        goToSleep(220 + ((initial_wait / 1000) - 2));
+        goToSleep(100 + ((initial_wait / 1000) - 2));
         USBPOW = 1;
         USBCIE = 0b0111;
         radioMacInit();
@@ -452,7 +452,7 @@ void timing_setup() {
         RFST = 4;
         delayMs(80);
         doServices();
-        goToSleep(220 + ((initial_wait / 1000) - 2));
+        goToSleep(100 + ((initial_wait / 1000) - 2));
         USBPOW = 1;
         USBCIE = 0b0111;
         radioMacInit();
@@ -473,7 +473,7 @@ void timing_setup() {
         RFST = 4;
         delayMs(80);
         doServices();
-        goToSleep(220 + ((initial_wait / 1000) - 2));
+        goToSleep(100 + ((initial_wait / 1000) - 2));
         USBPOW = 1;
         USBCIE = 0b0111;
         radioMacInit();
@@ -493,8 +493,8 @@ void timing_setup() {
     second_wait_second_channel = (getMs() % (60000 * 5));
     //set resleep values and default
 
-    fixed_wait_adder = (initial_wait + second_wait)/2;
-    wait_before_channel_switch = (first_wait_second_channel + second_wait_second_channel)/2 - fixed_wait_adder;
+    fixed_wait_adder = (initial_wait + second_wait) / 2;
+    wait_before_channel_switch = (first_wait_second_channel + second_wait_second_channel) / 2 - fixed_wait_adder;
 }
 
 void main() {
@@ -536,7 +536,7 @@ void main() {
         RFST = 4;
         delayMs(80);
         doServices();
-        goToSleep(220 + ((initial_wait / 1000) - 2));
+        goToSleep(100 + ((initial_wait / 1000) - 2));
         USBPOW = 1;
         USBCIE = 0b0111;
         radioMacInit();


### PR DESCRIPTION
The idea here is to time out how long we should be sleeping so we can make the most of it. Also it will burn through channel 0 for the next infinite cycles until it finds something again. This should prevent it getting stuck in a bad sleeping pattern and missing several in a row.

Just a test here though, may eat up battery!


Also, LOTS of XDATA because I ran out of PDATA long ago... :-(